### PR TITLE
Setup Vercel auto deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+MONGO_URI=mongodb+srv://sabuytube:.pQYUmj5%40wJ3umj@sabuytube.dqho6.mongodb.net/?ssl=true&authSource=admin
+MONGO_DB_NAME=sabuytube

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,0 +1,26 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Deploy to Vercel
+        uses: vercel/gh-action@v1
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ MONGO_DB_NAME=<your database name>
 
 ## Deployment
 
-The project is configured for deployment on Vercel. Ensure your environment variables are set in the Vercel dashboard.
+The project is configured for deployment on Vercel. Pushes to the `main` branch trigger the GitHub Actions workflow located in `.github/workflows/vercel.yml`, which builds and deploys the app using your Vercel project settings. Ensure the `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` secrets are configured in your repository, and that the required environment variables are defined in the Vercel dashboard.

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true
-  },
   webpack(config) {
     config.resolve.alias['@'] = __dirname + '/src';
     return config;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/react": "^18.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `.env` with Mongo connection details
- add GitHub Actions workflow for deploying to Vercel on push to main
- remove `experimental.appDir` from Next.js config
- add `@types/react` dev dependency
- document GitHub Actions deployment

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686f7c920db8832a97b719786d5dcc5b