### PR TITLE
Improve layout with navigation menu

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,30 @@
 import './globals.css';
 import { ReactNode } from 'react';
+import Link from 'next/link';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="container mx-auto p-4">{children}</body>
+      <body className="min-h-screen bg-gray-50">
+        <nav className="bg-gray-800 text-white">
+          <div className="container mx-auto p-4 flex items-center justify-between">
+            <div className="font-bold text-xl">Market Order</div>
+            <ul className="flex gap-4">
+              <li>
+                <Link href="/" className="hover:underline">
+                  Home
+                </Link>
+              </li>
+              <li>
+                <Link href="/order" className="hover:underline">
+                  Create Order
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </nav>
+        <main className="container mx-auto p-4">{children}</main>
+      </body>
     </html>
   );
 }

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -32,32 +32,38 @@ export default function OrderPage() {
   };
 
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Create Order</h1>
+    <div className="max-w-xl mx-auto bg-white shadow p-6 rounded">
+      <h1 className="text-2xl font-bold mb-6">Create Order</h1>
       {items.map((item, index) => (
-        <div key={index} className="mb-2 flex gap-2">
+        <div key={index} className="mb-3 flex gap-2">
           <input
-            className="border p-1"
+            className="border rounded p-2 flex-1"
             placeholder="Name"
             value={item.name}
             onChange={(e) => updateItem(index, 'name', e.target.value)}
           />
           <input
-            className="border p-1"
+            className="border rounded p-2 w-24"
             placeholder="Unit"
             value={item.unit}
             onChange={(e) => updateItem(index, 'unit', e.target.value)}
           />
           <input
             type="number"
-            className="border p-1 w-20"
+            className="border rounded p-2 w-24"
             value={item.quantity}
             onChange={(e) => updateItem(index, 'quantity', Number(e.target.value))}
           />
         </div>
       ))}
-      <button className="bg-blue-500 text-white px-4 py-2 mr-2" onClick={addItem}>Add Item</button>
-      <button className="bg-green-500 text-white px-4 py-2" onClick={submit}>Submit Order</button>
+      <div className="mt-4 flex justify-end gap-2">
+        <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={addItem}>
+          Add Item
+        </button>
+        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={submit}>
+          Submit Order
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,16 @@
+import Link from 'next/link';
+
 export default function HomePage() {
   return (
-    <div className="text-center">
-      <h1 className="text-2xl font-bold">Market Order System</h1>
-      <p className="mt-4">Go to /order to create a new order.</p>
+    <div className="text-center mt-10">
+      <h1 className="text-3xl font-bold mb-4">Market Order System</h1>
+      <p className="mb-6 text-gray-600">Create and manage market orders easily.</p>
+      <Link
+        href="/order"
+        className="inline-block bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700"
+      >
+        Create Order
+      </Link>
     </div>
   );
 }

--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -41,10 +41,10 @@ export default function SummaryPage() {
   const total = items.reduce((sum, item) => sum + (item.unitPrice || 0) * item.quantity, 0);
 
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Order Summary</h1>
+    <div className="max-w-2xl mx-auto bg-white shadow p-6 rounded">
+      <h1 className="text-2xl font-bold mb-6">Order Summary</h1>
       <div id="summary">
-        <table className="w-full mb-4 border">
+        <table className="w-full mb-4 border text-sm">
           <thead>
             <tr className="border-b">
               <th className="p-2 text-left">Name</th>
@@ -63,7 +63,7 @@ export default function SummaryPage() {
                 <td className="p-2 text-center">
                   <input
                     type="number"
-                    className="border p-1 w-24"
+                    className="border rounded p-2 w-24"
                     value={item.unitPrice || ''}
                     onChange={(e) => updatePrice(index, Number(e.target.value))}
                   />
@@ -77,8 +77,14 @@ export default function SummaryPage() {
         </table>
         <div className="text-right font-bold mb-4">Total: {total.toFixed(2)}</div>
       </div>
-      <button className="bg-blue-500 text-white px-4 py-2 mr-2" onClick={save}>Save Prices</button>
-      <button className="bg-green-500 text-white px-4 py-2" onClick={exportPDF}>Export PDF</button>
+      <div className="mt-4 flex justify-end gap-2">
+        <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={save}>
+          Save Prices
+        </button>
+        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={exportPDF}>
+          Export PDF
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add global navigation bar with links
- modernize the home page with CTA button
- style order entry form with card layout
- style summary page and buttons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f81d85414832aad86845071293712