### PR TITLE
Implement order export image feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "mongoose": "^7.4.0",
-    "html2pdf.js": "^0.10.1"
+    "html2canvas": "^1.4.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.15",

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -58,10 +58,10 @@ export default function OrderPage() {
       ))}
       <div className="mt-4 flex justify-end gap-2">
         <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={addItem}>
-          Add Item
+          + เพิ่มรายการ
         </button>
         <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={submit}>
-          Submit Order
+          ส่งใบสั่งซื้อ
         </button>
       </div>
     </div>

--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
-import html2pdf from 'html2pdf.js';
+import html2canvas from 'html2canvas';
 
 interface Item {
   name: string;
@@ -20,25 +20,15 @@ export default function SummaryPage() {
       .then((data) => setItems(data.items));
   }, [id]);
 
-  const updatePrice = (index: number, value: number) => {
-    setItems((prev) => prev.map((item, i) => (i === index ? { ...item, unitPrice: value } : item)));
-  };
-
-  const save = async () => {
-    await fetch(`/api/orders/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ items }),
-    });
-  };
-
-  const exportPDF = () => {
+  const exportImage = useCallback(async () => {
     const element = document.getElementById('summary');
     if (!element) return;
-    html2pdf().from(element).save(`order-${id}.pdf`);
-  };
-
-  const total = items.reduce((sum, item) => sum + (item.unitPrice || 0) * item.quantity, 0);
+    const canvas = await html2canvas(element);
+    const link = document.createElement('a');
+    link.href = canvas.toDataURL('image/png');
+    link.download = `order-${id}.png`;
+    link.click();
+  }, [id]);
 
   return (
     <div className="max-w-2xl mx-auto bg-white shadow p-6 rounded">
@@ -50,8 +40,6 @@ export default function SummaryPage() {
               <th className="p-2 text-left">Name</th>
               <th className="p-2">Unit</th>
               <th className="p-2">Qty</th>
-              <th className="p-2">Unit Price</th>
-              <th className="p-2">Total</th>
             </tr>
           </thead>
           <tbody>
@@ -60,29 +48,14 @@ export default function SummaryPage() {
                 <td className="p-2">{item.name}</td>
                 <td className="p-2 text-center">{item.unit}</td>
                 <td className="p-2 text-center">{item.quantity}</td>
-                <td className="p-2 text-center">
-                  <input
-                    type="number"
-                    className="border rounded p-2 w-24"
-                    value={item.unitPrice || ''}
-                    onChange={(e) => updatePrice(index, Number(e.target.value))}
-                  />
-                </td>
-                <td className="p-2 text-right">
-                  {((item.unitPrice || 0) * item.quantity).toFixed(2)}
-                </td>
               </tr>
             ))}
           </tbody>
         </table>
-        <div className="text-right font-bold mb-4">Total: {total.toFixed(2)}</div>
       </div>
-      <div className="mt-4 flex justify-end gap-2">
-        <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={save}>
-          Save Prices
-        </button>
-        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={exportPDF}>
-          Export PDF
+      <div className="mt-4 flex justify-end">
+        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={exportImage}>
+          Save as Image
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `html2canvas` and remove pdf library
- update Order page buttons in Thai
- simplify order summary without unit price column
- export summary table as PNG image

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f86836424832a9d30f714260e13dc