### PR TITLE
Add product autocomplete and order history

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -8,3 +8,9 @@ export async function POST(req: Request) {
   const order = await Order.create(data);
   return NextResponse.json({ id: order._id });
 }
+
+export async function GET() {
+  await connectDB();
+  const orders = await Order.find();
+  return NextResponse.json(orders);
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import Product from '@/models/Product';
+import { connectDB } from '@/lib/mongodb';
+
+export async function GET() {
+  await connectDB();
+  const products = await Product.find().sort({ name: 1 });
+  return NextResponse.json(products);
+}
+
+export async function POST(req: Request) {
+  await connectDB();
+  const data = await req.json();
+  const product = await Product.create(data);
+  return NextResponse.json(product);
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface Order {
+  _id: string;
+  items: { name: string; unit: string; quantity: number }[];
+}
+
+export default function HistoryPage() {
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    fetch('/api/orders')
+      .then((res) => res.json())
+      .then((data) => setOrders(data));
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto bg-white shadow p-6 rounded">
+      <h1 className="text-2xl font-bold mb-6">Order History</h1>
+      <table className="w-full border text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">Order ID</th>
+            <th className="p-2 text-center">Items</th>
+            <th className="p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((order) => (
+            <tr key={order._id} className="border-b">
+              <td className="p-2">{order._id}</td>
+              <td className="p-2 text-center">{order.items.length}</td>
+              <td className="p-2 text-center">
+                <Link href={`/summary/${order._id}`} className="text-blue-600 hover:underline">
+                  View
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                   Create Order
                 </Link>
               </li>
+              <li>
+                <Link href="/history" className="hover:underline">
+                  History
+                </Link>
+              </li>
             </ul>
           </div>
         </nav>

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
 interface Item {
@@ -11,6 +11,24 @@ interface Item {
 export default function OrderPage() {
   const router = useRouter();
   const [items, setItems] = useState<Item[]>([{ name: '', unit: '', quantity: 1 }]);
+  const [products, setProducts] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch('/api/products')
+      .then((res) => res.json())
+      .then((data) => setProducts(data.map((p: { name: string }) => p.name)));
+  }, []);
+
+  const addProduct = async () => {
+    const name = prompt('Product name');
+    if (!name) return;
+    await fetch('/api/products', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    setProducts((prev) => [...prev, name]);
+  };
 
   const addItem = () => {
     setItems([...items, { name: '', unit: '', quantity: 1 }]);
@@ -35,13 +53,28 @@ export default function OrderPage() {
     <div className="max-w-xl mx-auto bg-white shadow p-6 rounded">
       <h1 className="text-2xl font-bold mb-6">Create Order</h1>
       {items.map((item, index) => (
-        <div key={index} className="mb-3 flex gap-2">
-          <input
-            className="border rounded p-2 flex-1"
-            placeholder="Name"
-            value={item.name}
-            onChange={(e) => updateItem(index, 'name', e.target.value)}
-          />
+        <div key={index} className="mb-3 flex gap-2 items-center">
+          <div className="flex-1 relative">
+            <input
+              list={`products-${index}`}
+              className="border rounded p-2 w-full"
+              placeholder="Name"
+              value={item.name}
+              onChange={(e) => updateItem(index, 'name', e.target.value)}
+            />
+            <datalist id={`products-${index}`}>
+              {products.map((p) => (
+                <option key={p} value={p} />
+              ))}
+            </datalist>
+          </div>
+          <button
+            type="button"
+            onClick={addProduct}
+            className="px-2 bg-gray-200 rounded"
+          >
+            +
+          </button>
           <input
             className="border rounded p-2 w-24"
             placeholder="Unit"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,12 @@ export default function HomePage() {
       >
         Create Order
       </Link>
+      <Link
+        href="/history"
+        className="inline-block bg-gray-600 text-white px-6 py-3 rounded hover:bg-gray-700 ml-4"
+      >
+        View History
+      </Link>
     </div>
   );
 }

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -1,0 +1,11 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface ProductDocument extends Document {
+  name: string;
+}
+
+const ProductSchema = new Schema<ProductDocument>({
+  name: { type: String, required: true },
+});
+
+export default mongoose.models.Product || mongoose.model<ProductDocument>('Product', ProductSchema);


### PR DESCRIPTION
## Summary
- create `Product` model
- create API route `/api/products` for listing and adding products
- allow creating orders with product autocomplete and ability to add products
- expose GET `/api/orders` and build new order history page
- add navigation & home links to History

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f897103ec832a9f01d3211105a4a4