### PR TITLE
Update pages for new order fields

### DIFF
--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -5,12 +5,11 @@ import { useRouter } from 'next/navigation';
 interface Item {
   name: string;
   unit: string;
-  quantity: number;
 }
 
 export default function OrderPage() {
   const router = useRouter();
-  const [items, setItems] = useState<Item[]>([{ name: '', unit: '', quantity: 1 }]);
+  const [items, setItems] = useState<Item[]>([{ name: '', unit: '' }]);
   const [products, setProducts] = useState<string[]>([]);
 
   useEffect(() => {
@@ -31,10 +30,10 @@ export default function OrderPage() {
   };
 
   const addItem = () => {
-    setItems([...items, { name: '', unit: '', quantity: 1 }]);
+    setItems([...items, { name: '', unit: '' }]);
   };
 
-  const updateItem = (index: number, field: keyof Item, value: string | number) => {
+  const updateItem = (index: number, field: keyof Item, value: string) => {
     const updated = items.map((item, i) => (i === index ? { ...item, [field]: value } : item));
     setItems(updated);
   };
@@ -80,12 +79,6 @@ export default function OrderPage() {
             placeholder="Unit"
             value={item.unit}
             onChange={(e) => updateItem(index, 'unit', e.target.value)}
-          />
-          <input
-            type="number"
-            className="border rounded p-2 w-24"
-            value={item.quantity}
-            onChange={(e) => updateItem(index, 'quantity', Number(e.target.value))}
           />
         </div>
       ))}

--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -39,7 +39,7 @@ export default function SummaryPage() {
             <tr className="border-b">
               <th className="p-2 text-left">Name</th>
               <th className="p-2">Unit</th>
-              <th className="p-2">Qty</th>
+              <th className="p-2">Price</th>
             </tr>
           </thead>
           <tbody>
@@ -47,7 +47,7 @@ export default function SummaryPage() {
               <tr key={index} className="border-b">
                 <td className="p-2">{item.name}</td>
                 <td className="p-2 text-center">{item.unit}</td>
-                <td className="p-2 text-center">{item.quantity}</td>
+                <td className="p-2 text-center"></td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary
- remove quantity input from order creation page
- update summary table to show blank `Price` column

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f90d89630832a8b297272428d04ef