### PR TITLE
Add Thai localization and CRUD features

### DIFF
--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -14,3 +14,9 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
   const order = await Order.findByIdAndUpdate(params.id, data, { new: true });
   return NextResponse.json(order);
 }
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  await connectDB();
+  await Order.findByIdAndDelete(params.id);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -16,15 +16,28 @@ export default function HistoryPage() {
       .then((data) => setOrders(data));
   }, []);
 
+  const remove = async (id: string) => {
+    await fetch(`/api/orders/${id}`, { method: 'DELETE' });
+    setOrders((prev) => prev.filter((o) => o._id !== id));
+  };
+
   return (
     <div className="max-w-2xl mx-auto bg-white shadow p-6 rounded">
-      <h1 className="text-2xl font-bold mb-6">Order History</h1>
+      <h1 className="text-2xl font-bold mb-6">ประวัติการสั่งซื้อ</h1>
+      <div className="mb-4 text-right">
+        <Link
+          href="/order"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          สร้างใบสั่งซื้อ
+        </Link>
+      </div>
       <table className="w-full border text-sm">
         <thead>
           <tr className="border-b">
-            <th className="p-2 text-left">Order ID</th>
-            <th className="p-2 text-center">Items</th>
-            <th className="p-2"></th>
+            <th className="p-2 text-left">รหัสคำสั่งซื้อ</th>
+            <th className="p-2 text-center">จำนวนรายการ</th>
+            <th className="p-2 text-center">การจัดการ</th>
           </tr>
         </thead>
         <tbody>
@@ -32,10 +45,16 @@ export default function HistoryPage() {
             <tr key={order._id} className="border-b">
               <td className="p-2">{order._id}</td>
               <td className="p-2 text-center">{order.items.length}</td>
-              <td className="p-2 text-center">
+              <td className="p-2 text-center space-x-2">
                 <Link href={`/summary/${order._id}`} className="text-blue-600 hover:underline">
-                  View
+                  ดู
                 </Link>
+                <Link href={`/order/${order._id}`} className="text-green-600 hover:underline">
+                  แก้ไข
+                </Link>
+                <button onClick={() => remove(order._id)} className="text-red-600 hover:underline">
+                  ลบ
+                </button>
               </td>
             </tr>
           ))}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,25 +4,25 @@ import Link from 'next/link';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="th">
       <body className="min-h-screen bg-gray-50">
         <nav className="bg-gray-800 text-white">
           <div className="container mx-auto p-4 flex items-center justify-between">
-            <div className="font-bold text-xl">Market Order</div>
+            <div className="font-bold text-xl">ระบบจัดการคำสั่งซื้อ</div>
             <ul className="flex gap-4">
               <li>
                 <Link href="/" className="hover:underline">
-                  Home
+                  หน้าแรก
                 </Link>
               </li>
               <li>
                 <Link href="/order" className="hover:underline">
-                  Create Order
+                  สร้างใบสั่งซื้อ
                 </Link>
               </li>
               <li>
                 <Link href="/history" className="hover:underline">
-                  History
+                  ดูย้อนหลัง
                 </Link>
               </li>
             </ul>

--- a/src/app/order/[id]/page.tsx
+++ b/src/app/order/[id]/page.tsx
@@ -1,15 +1,16 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 
 interface Item {
   name: string;
   unit: string;
 }
 
-export default function OrderPage() {
+export default function EditOrderPage() {
   const router = useRouter();
-  const [items, setItems] = useState<Item[]>([{ name: '', unit: '' }]);
+  const { id } = useParams();
+  const [items, setItems] = useState<Item[]>([]);
   const [products, setProducts] = useState<string[]>([]);
 
   useEffect(() => {
@@ -17,6 +18,12 @@ export default function OrderPage() {
       .then((res) => res.json())
       .then((data) => setProducts(data.map((p: { name: string }) => p.name)));
   }, []);
+
+  useEffect(() => {
+    fetch(`/api/orders/${id}`)
+      .then((res) => res.json())
+      .then((data) => setItems(data.items));
+  }, [id]);
 
   const addProduct = async () => {
     const name = prompt('ชื่อสินค้า');
@@ -33,24 +40,27 @@ export default function OrderPage() {
     setItems([...items, { name: '', unit: '' }]);
   };
 
+  const removeItem = (index: number) => {
+    setItems(items.filter((_, i) => i !== index));
+  };
+
   const updateItem = (index: number, field: keyof Item, value: string) => {
     const updated = items.map((item, i) => (i === index ? { ...item, [field]: value } : item));
     setItems(updated);
   };
 
   const submit = async () => {
-    const res = await fetch('/api/orders', {
-      method: 'POST',
+    await fetch(`/api/orders/${id}`, {
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ items }),
     });
-    const data = await res.json();
-    router.push(`/summary/${data.id}`);
+    router.push(`/summary/${id}`);
   };
 
   return (
     <div className="max-w-xl mx-auto bg-white shadow p-6 rounded">
-      <h1 className="text-2xl font-bold mb-6">สร้างใบสั่งซื้อ</h1>
+      <h1 className="text-2xl font-bold mb-6">แก้ไขใบสั่งซื้อ</h1>
       {items.map((item, index) => (
         <div key={index} className="mb-3 flex gap-2 items-center">
           <div className="flex-1 relative">
@@ -67,11 +77,7 @@ export default function OrderPage() {
               ))}
             </datalist>
           </div>
-          <button
-            type="button"
-            onClick={addProduct}
-            className="px-2 bg-gray-200 rounded"
-          >
+          <button type="button" onClick={addProduct} className="px-2 bg-gray-200 rounded">
             +
           </button>
           <input
@@ -80,6 +86,13 @@ export default function OrderPage() {
             value={item.unit}
             onChange={(e) => updateItem(index, 'unit', e.target.value)}
           />
+          <button
+            type="button"
+            onClick={() => removeItem(index)}
+            className="px-2 bg-red-500 text-white rounded"
+          >
+            x
+          </button>
         </div>
       ))}
       <div className="mt-4 flex justify-end gap-2">
@@ -87,7 +100,7 @@ export default function OrderPage() {
           + เพิ่มรายการ
         </button>
         <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={submit}>
-          ส่งใบสั่งซื้อ
+          บันทึก
         </button>
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,19 +3,19 @@ import Link from 'next/link';
 export default function HomePage() {
   return (
     <div className="text-center mt-10">
-      <h1 className="text-3xl font-bold mb-4">Market Order System</h1>
-      <p className="mb-6 text-gray-600">Create and manage market orders easily.</p>
+      <h1 className="text-3xl font-bold mb-4">ระบบจัดการคำสั่งซื้อ</h1>
+      <p className="mb-6 text-gray-600">สร้างและจัดการคำสั่งซื้อได้ง่ายๆ</p>
       <Link
         href="/order"
         className="inline-block bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700"
       >
-        Create Order
+        สร้างใบสั่งซื้อ
       </Link>
       <Link
         href="/history"
         className="inline-block bg-gray-600 text-white px-6 py-3 rounded hover:bg-gray-700 ml-4"
       >
-        View History
+        ดูย้อนหลัง
       </Link>
     </div>
   );

--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -22,24 +22,26 @@ export default function SummaryPage() {
 
   const exportImage = useCallback(async () => {
     const element = document.getElementById('summary');
-    if (!element) return;
+    if (!element || !('clipboard' in navigator)) return;
     const canvas = await html2canvas(element);
-    const link = document.createElement('a');
-    link.href = canvas.toDataURL('image/png');
-    link.download = `order-${id}.png`;
-    link.click();
+    canvas.toBlob(async (blob) => {
+      if (!blob) return;
+      await navigator.clipboard.write([
+        new ClipboardItem({ 'image/png': blob }) as any,
+      ]);
+    });
   }, [id]);
 
   return (
     <div className="max-w-2xl mx-auto bg-white shadow p-6 rounded">
-      <h1 className="text-2xl font-bold mb-6">Order Summary</h1>
+      <h1 className="text-2xl font-bold mb-6">สรุปคำสั่งซื้อ</h1>
       <div id="summary">
         <table className="w-full mb-4 border text-sm">
           <thead>
             <tr className="border-b">
-              <th className="p-2 text-left">Name</th>
-              <th className="p-2">Unit</th>
-              <th className="p-2">Price</th>
+              <th className="p-2 text-left">ชื่อสินค้า</th>
+              <th className="p-2">หน่วย</th>
+              <th className="p-2">ราคา</th>
             </tr>
           </thead>
           <tbody>
@@ -55,7 +57,7 @@ export default function SummaryPage() {
       </div>
       <div className="mt-4 flex justify-end">
         <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={exportImage}>
-          Save as Image
+          คัดลอกรูปภาพ
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- localize app pages in Thai
- add edit/delete features in history page
- implement order editing page
- copy order summary to clipboard instead of saving image
- add DELETE API route for orders

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9a84d2c0832aa92a168274dbe715