### PR TITLE
Display orders on home page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,21 +8,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="min-h-screen bg-gray-50">
         <nav className="bg-gray-800 text-white">
           <div className="container mx-auto p-4 flex items-center justify-between">
-            <div className="font-bold text-xl">ระบบจัดการคำสั่งซื้อ</div>
+            <Link href="/" className="font-bold text-xl hover:underline">
+              ระบบจัดการคำสั่งซื้อ
+            </Link>
             <ul className="flex gap-4">
-              <li>
-                <Link href="/" className="hover:underline">
-                  หน้าแรก
-                </Link>
-              </li>
               <li>
                 <Link href="/order" className="hover:underline">
                   สร้างใบสั่งซื้อ
-                </Link>
-              </li>
-              <li>
-                <Link href="/history" className="hover:underline">
-                  ดูย้อนหลัง
                 </Link>
               </li>
             </ul>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,61 @@
+'use client';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+interface Order {
+  _id: string;
+  shopName: string;
+  items: { name: string; unit: string; quantity: number }[];
+}
 
 export default function HomePage() {
+  const router = useRouter();
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    fetch('/api/orders')
+      .then((res) => res.json())
+      .then((data) => setOrders(data));
+  }, []);
+
   return (
-    <div className="text-center mt-10">
-      <h1 className="text-3xl font-bold mb-4">ระบบจัดการคำสั่งซื้อ</h1>
-      <p className="mb-6 text-gray-600">สร้างและจัดการคำสั่งซื้อได้ง่ายๆ</p>
-      <Link
-        href="/order"
-        className="inline-block bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700"
-      >
-        สร้างใบสั่งซื้อ
-      </Link>
-      <Link
-        href="/history"
-        className="inline-block bg-gray-600 text-white px-6 py-3 rounded hover:bg-gray-700 ml-4"
-      >
-        ดูย้อนหลัง
-      </Link>
+    <div className="mt-10 max-w-2xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4 text-center">ระบบจัดการคำสั่งซื้อ</h1>
+      <p className="mb-6 text-gray-600 text-center">
+        สร้างและจัดการคำสั่งซื้อได้ง่ายๆ
+      </p>
+      <div className="text-center mb-6">
+        <Link
+          href="/order"
+          className="inline-block bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700"
+        >
+          สร้างใบสั่งซื้อ
+        </Link>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {orders.map((order) => (
+          <div
+            key={order._id}
+            className="border rounded p-4 hover:bg-gray-50 cursor-pointer"
+            onClick={() => router.push(`/summary/${order._id}`)}
+          >
+            <div className="font-semibold">{order.shopName}</div>
+            <div className="text-sm text-gray-500">
+              จำนวนรายการ {order.items.length}
+            </div>
+            <div className="mt-2 text-right">
+              <Link
+                href={`/order/${order._id}`}
+                className="bg-blue-600 text-white px-3 py-1 rounded"
+                onClick={(e) => e.stopPropagation()}
+              >
+                แก้ไข
+              </Link>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- link app title to home and drop extra nav links
- show editable order cards in two columns on home page

## Testing
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687069645174832aaea3b8027ef40b47