### PR TITLE
Add shop name row in order summary table

### DIFF
--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -54,6 +54,11 @@ export default function SummaryPage() {
             </tr>
           </thead>
           <tbody>
+            <tr>
+              <td colSpan={3} className="p-2 font-semibold text-center">
+                {shopName}
+              </td>
+            </tr>
             {items.map((item, index) => (
               <tr key={index} className="border-b">
                 <td className="p-2">{item.name}</td>


### PR DESCRIPTION
## Summary
- include shop name as the first row of the summary table so that screenshots contain the store name

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870764851cc832abef1596926959b6f