### PR TITLE
Add comment column and Burmese notes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,25 +1,31 @@
+'use client';
 import './globals.css';
 import { ReactNode } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const showNav = !pathname.startsWith('/price');
   return (
     <html lang="th">
       <body className="min-h-screen bg-gray-50">
-        <nav className="bg-gray-800 text-white">
-          <div className="container mx-auto p-4 flex items-center justify-between">
-            <Link href="/" className="font-bold text-xl hover:underline">
-              ระบบจัดการคำสั่งซื้อ
-            </Link>
-            <ul className="flex gap-4">
-              <li>
-                <Link href="/order" className="hover:underline">
-                  สร้างใบสั่งซื้อ
-                </Link>
-              </li>
-            </ul>
-          </div>
-        </nav>
+        {showNav && (
+          <nav className="bg-gray-800 text-white">
+            <div className="container mx-auto p-4 flex items-center justify-between">
+              <Link href="/" className="font-bold text-xl hover:underline">
+                ระบบจัดการคำสั่งซื้อ
+              </Link>
+              <ul className="flex gap-4">
+                <li>
+                  <Link href="/order" className="hover:underline">
+                    สร้างใบสั่งซื้อ
+                  </Link>
+                </li>
+              </ul>
+            </div>
+          </nav>
+        )}
         <main className="container mx-auto p-4">{children}</main>
       </body>
     </html>

--- a/src/app/price/[id]/page.tsx
+++ b/src/app/price/[id]/page.tsx
@@ -6,6 +6,7 @@ interface Item {
   name: string;
   unit: string;
   unitPrice?: number;
+  comment?: string;
 }
 
 export default function PricePage() {
@@ -32,6 +33,13 @@ export default function PricePage() {
     setItems(updated);
   };
 
+  const updateComment = (index: number, value: string) => {
+    const updated = items.map((item, i) =>
+      i === index ? { ...item, comment: value } : item
+    );
+    setItems(updated);
+  };
+
   const submit = async () => {
     await fetch(`/api/orders/${id}`, {
       method: 'PUT',
@@ -45,7 +53,11 @@ export default function PricePage() {
   };
 
   const clearPrices = async () => {
-    const cleared = items.map((item) => ({ ...item, unitPrice: undefined }));
+    const cleared = items.map((item) => ({
+      ...item,
+      unitPrice: undefined,
+      comment: '',
+    }));
     setItems(cleared);
     await fetch(`/api/orders/${id}`, {
       method: 'PUT',
@@ -57,12 +69,14 @@ export default function PricePage() {
 
   return (
     <div className="max-w-xl mx-auto bg-white shadow p-6 rounded">
-      <h1 className="text-2xl font-bold mb-6">กำหนดราคา</h1>
+      <h1 className="text-2xl font-bold">กำหนดราคา (သတ်မှတ်ဈေး)</h1>
+      <p className="mb-6">หมายเหตุ โล:ကီလို, ลูก:လုံး, หัว:ထောင်, กำ:ည</p>
       <table className="w-full mb-2 text-sm">
         <thead>
           <tr className="border-b">
             <th className="p-2 text-left">ชื่อสินค้า</th>
             <th className="p-2 text-center">หน่วย</th>
+            <th className="p-2 text-center">comment</th>
             <th className="p-2 text-center">ราคา</th>
           </tr>
         </thead>
@@ -71,6 +85,14 @@ export default function PricePage() {
             <tr key={index} className="border-b">
               <td className="p-2">{item.name}</td>
               <td className="p-2 text-center">{item.unit}</td>
+              <td className="p-2 text-center">
+                <input
+                  type="text"
+                  className="border rounded p-1 w-24"
+                  value={item.comment ?? ''}
+                  onChange={(e) => updateComment(index, e.target.value)}
+                />
+              </td>
               <td className="p-2 text-center">
                 <input
                   type="number"
@@ -84,7 +106,7 @@ export default function PricePage() {
         </tbody>
         <tfoot>
           <tr>
-            <td colSpan={2} className="p-2 font-semibold text-right">
+            <td colSpan={3} className="p-2 font-semibold text-right">
               รวม
             </td>
             <td className="p-2 text-center font-semibold">{total}</td>
@@ -92,8 +114,8 @@ export default function PricePage() {
         </tfoot>
       </table>
       <div className="mt-4 flex justify-between">
-        <button className="text-red-600" onClick={clearPrices}>
-          ลบราคา
+        <button className="text-red-600 hidden" onClick={clearPrices}>
+          clear
         </button>
         <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={submit}>
           บันทึกราคา

--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -8,6 +8,7 @@ interface Item {
   unit: string;
   quantity: number;
   unitPrice?: number;
+  comment?: string;
 }
 
 export default function SummaryPage() {
@@ -22,7 +23,11 @@ export default function SummaryPage() {
   );
 
   const clearPrices = async () => {
-    const cleared = items.map((item) => ({ ...item, unitPrice: undefined }));
+    const cleared = items.map((item) => ({
+      ...item,
+      unitPrice: undefined,
+      comment: '',
+    }));
     setItems(cleared);
     await fetch(`/api/orders/${id}`, {
       method: 'PUT',
@@ -69,6 +74,7 @@ export default function SummaryPage() {
             <tr className="border-b">
               <th className="p-2 text-left">ชื่อสินค้า</th>
               <th className="p-2">หน่วย</th>
+              <th className="p-2">comment</th>
               <th className="p-2">ราคา</th>
             </tr>
           </thead>
@@ -77,13 +83,14 @@ export default function SummaryPage() {
               <tr key={index} className="border-b">
                 <td className="p-2">{item.name}</td>
                 <td className="p-2 text-center">{item.unit}</td>
+                <td className="p-2 text-center">{item.comment ?? ''}</td>
                 <td className="p-2 text-center">{item.unitPrice ?? ''}</td>
               </tr>
             ))}
           </tbody>
           <tfoot>
             <tr>
-              <td colSpan={2} className="p-2 font-semibold text-right">รวม</td>
+              <td colSpan={3} className="p-2 font-semibold text-right">รวม</td>
               <td className="p-2 text-center font-semibold">{total}</td>
             </tr>
           </tfoot>
@@ -91,7 +98,7 @@ export default function SummaryPage() {
         </div>
         <div className="mt-4 flex justify-between">
           <button className="text-red-600" onClick={clearPrices}>
-            ลบราคา
+            clear
           </button>
         </div>
     </div>

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -5,6 +5,7 @@ type Item = {
   unit: string;
   quantity: number;
   unitPrice?: number;
+  comment?: string;
 };
 
 export interface OrderDocument extends Document {
@@ -17,6 +18,7 @@ const ItemSchema = new Schema<Item>({
   unit: String,
   quantity: Number,
   unitPrice: Number,
+  comment: String,
 });
 
 const OrderSchema = new Schema<OrderDocument>({


### PR DESCRIPTION
## Summary
- expand order item with optional `comment` field
- add comment column on price page and summary page
- rename clear price button text to `clear`
- hide navigation bar on price pages
- hide `clear` button on price page for now
- show Burmese translation beside heading on price page and add note about unit translations

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750a09060c832ab458b6e49a3d6c2b