### PR TITLE
Fix order save issues and enforce shop name

### DIFF
--- a/src/app/order/[id]/page.tsx
+++ b/src/app/order/[id]/page.tsx
@@ -109,7 +109,11 @@ export default function EditOrderPage() {
         <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={addItem}>
           + เพิ่มรายการ
         </button>
-        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={submit}>
+        <button
+          className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+          onClick={submit}
+          disabled={!shopName.trim()}
+        >
           บันทึก
         </button>
       </div>

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -93,7 +93,11 @@ export default function OrderPage() {
         <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={addItem}>
           + เพิ่มรายการ
         </button>
-        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={submit}>
+        <button
+          className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+          onClick={submit}
+          disabled={!shopName.trim()}
+        >
           ส่งใบสั่งซื้อ
         </button>
       </div>

--- a/src/app/price/[id]/page.tsx
+++ b/src/app/price/[id]/page.tsx
@@ -14,6 +14,7 @@ export default function PricePage() {
   const { id } = useParams();
   const [shopName, setShopName] = useState('');
   const [items, setItems] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(true);
   const total = items.reduce((sum, item) => sum + (item.unitPrice || 0), 0);
 
   useEffect(() => {
@@ -22,7 +23,9 @@ export default function PricePage() {
       .then((data) => {
         setShopName(data.shopName);
         setItems(data.items);
-      });
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
   }, [id]);
 
   const updatePrice = (index: number, value: string) => {
@@ -41,6 +44,7 @@ export default function PricePage() {
   };
 
   const submit = async () => {
+    if (loading) return;
     await fetch(`/api/orders/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -53,6 +57,7 @@ export default function PricePage() {
   };
 
   const clearPrices = async () => {
+    if (loading) return;
     const cleared = items.map((item) => ({
       ...item,
       unitPrice: undefined,
@@ -114,10 +119,18 @@ export default function PricePage() {
         </tfoot>
       </table>
       <div className="mt-4 flex justify-between">
-        <button className="text-red-600 hidden" onClick={clearPrices}>
+        <button
+          className="text-red-600 hidden disabled:opacity-50"
+          onClick={clearPrices}
+          disabled={loading}
+        >
           clear
         </button>
-        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={submit}>
+        <button
+          className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+          onClick={submit}
+          disabled={loading}
+        >
           บันทึกราคา
         </button>
       </div>

--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -17,12 +17,14 @@ export default function SummaryPage() {
   const [items, setItems] = useState<Item[]>([]);
   const [shopName, setShopName] = useState('');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
   const total = items.reduce(
     (sum, item) => sum + ((item.unitPrice || 0) * (item.quantity || 1)),
     0
   );
 
   const clearPrices = async () => {
+    if (loading) return;
     const cleared = items.map((item) => ({
       ...item,
       unitPrice: undefined,
@@ -45,7 +47,9 @@ export default function SummaryPage() {
       .then((data) => {
         setShopName(data.shopName);
         setItems(data.items);
-      });
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
   }, [id]);
 
 
@@ -97,7 +101,11 @@ export default function SummaryPage() {
         </table>
         </div>
         <div className="mt-4 flex justify-between">
-          <button className="text-red-600" onClick={clearPrices}>
+          <button
+            className="text-red-600 disabled:opacity-50"
+            onClick={clearPrices}
+            disabled={loading}
+          >
             clear
           </button>
         </div>


### PR DESCRIPTION
## Summary
- require shop name for order creation and editing
- disable save/clear buttons until data is loaded

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879b6ff7e00832a9745dd6ad3da7edd