### PR TITLE
Add numbering to summary page

### DIFF
--- a/src/app/summary/[id]/page.tsx
+++ b/src/app/summary/[id]/page.tsx
@@ -77,6 +77,7 @@ export default function SummaryPage() {
           <caption className="p-2 font-semibold text-center">{shopName}</caption>
           <thead>
             <tr className="border-b">
+              <th className="p-2 text-center">ลำดับ</th>
               <th className="p-2 text-left">ชื่อสินค้า</th>
               <th className="p-2">หน่วย</th>
               <th className="p-2">comment</th>
@@ -86,6 +87,7 @@ export default function SummaryPage() {
           <tbody>
             {items.map((item, index) => (
               <tr key={index} className="border-b">
+                <td className="p-2 text-center">{index + 1}</td>
                 <td className="p-2">{item.name}</td>
                 <td className="p-2 text-center">{item.unit}</td>
                 <td className="p-2 text-center">{item.comment ?? ''}</td>
@@ -95,7 +97,7 @@ export default function SummaryPage() {
           </tbody>
           <tfoot>
             <tr>
-              <td colSpan={3} className="p-2 font-semibold text-right">รวม</td>
+              <td colSpan={4} className="p-2 font-semibold text-right">รวม</td>
               <td className="p-2 text-center font-semibold">{total}</td>
             </tr>
           </tfoot>


### PR DESCRIPTION
## Summary
- show item sequence numbers in order summary table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: asks for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddd7a258832a9d9d0f4d40dd265e